### PR TITLE
feat: add translation-only subtitle mode

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -25,22 +25,19 @@ export default defineBackground(() => {
     throw new Error('Unknown response format');
   }
 
-  browser.runtime.onMessage.addListener(async (message: ExtensionMessage, sender, sendResponse) => {
+  browser.runtime.onMessage.addListener((message: ExtensionMessage, sender, sendResponse) => {
     switch (message.action) {
       case ExtensionMessageAction.Translate:
-        try {
-          const { text, source_lang, target_lang } = message.payload;
-          const translation = await getTranslation(text, source_lang, target_lang);
-          return {
-            error: null,
-            response: translation
-          };
-        } catch (e) {
-          return {
-            error: e,
-            response: null
-          };
-        }
+        (async () => {
+          try {
+            const { text, source_lang, target_lang } = message.payload;
+            const translation = await getTranslation(text, source_lang, target_lang);
+            sendResponse({ error: null, response: translation });
+          } catch (e) {
+            sendResponse({ error: e, response: null });
+          }
+        })();
+        return true;
     }
   });
 });

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -20,13 +20,19 @@ export default defineContentScript({
       subtitleContainer.style.left = '0%';
     }
 
+    function hideOriginalSubtitle() {
+      const subtitleContainer = document.querySelector('tv-player-subtitles div') as HTMLDivElement;
+      subtitleContainer.style.opacity = '0';
+    }
+
     function resetOriginalSubtitle() {
       const subtitleContainer = document.querySelector('tv-player-subtitles div') as HTMLDivElement;
       subtitleContainer.style.width = '100%';
+      subtitleContainer.style.opacity = '1';
       subtitleContainer.style.left = 'unset';
     }
 
-    function appendTranslatedSubtitle(content: string) {
+    function appendTranslatedSubtitle(content: string, width = '50%') {
       const subtitleContainer = document.querySelector('tv-player-subtitles div') as HTMLDivElement;
       const translateContainer = subtitleContainer.cloneNode(true) as HTMLDivElement;
       const translateSubtitleText = translateContainer.querySelector('.tv-player-subtitle-text') as HTMLSpanElement;
@@ -34,7 +40,7 @@ export default defineContentScript({
       translateSubtitleText.innerText = content;
       translateContainer.style.left = 'unset';
       translateContainer.style.right = '0%';
-      translateContainer.style.width = '50%';
+      translateContainer.style.width = width;
       translateContainer.style.opacity = '1';
       translateContainer.setAttribute('data-translated', 'true');
       subtitleContainer.parentElement?.appendChild(translateContainer);
@@ -73,11 +79,18 @@ export default defineContentScript({
     document.addEventListener('keydown', (e) => {
       if (e.key === ACTIVATION_KEY) {
         activationKeyPressed = true;
-        if (mode === TranslateMode.KeyPress) {
-          const video = document.querySelector('tv-player video') as HTMLVideoElement;
-          showTranslatedSubtitle();
-          video.pause();
-          video.focus();
+        const video = document.querySelector('tv-player video') as HTMLVideoElement;
+        switch (mode) {
+          case TranslateMode.KeyPress:
+            showTranslatedSubtitle();
+            video.pause();
+            video.focus();
+            break;
+          case TranslateMode.OnlyTranslation:
+            hideTranslatedSubtitle();
+            video.pause();
+            video.focus();
+            break;
         }
       }
     });
@@ -85,11 +98,19 @@ export default defineContentScript({
     document.addEventListener('keyup', (e) => {
       if (e.key === ACTIVATION_KEY) {
         activationKeyPressed = false;
-        if (mode === TranslateMode.KeyPress) {
-          const video = document.querySelector('tv-player video') as HTMLVideoElement;
-          hideTranslatedSubtitle();
-          video.play();
-          video.focus();
+        const video = document.querySelector('tv-player video') as HTMLVideoElement;
+        switch (mode) {
+          case TranslateMode.KeyPress:
+            hideTranslatedSubtitle();
+            video.play();
+            video.focus();
+            break;
+          case TranslateMode.OnlyTranslation:
+            hideOriginalSubtitle();
+            showTranslatedSubtitle();
+            video.play();
+            video.focus();
+            break;
         }
       }
     });
@@ -114,6 +135,17 @@ export default defineContentScript({
           removeTranslatedSubtitle();
           appendTranslatedSubtitle(translation);
           if (!activationKeyPressed) hideTranslatedSubtitle();
+          break;
+        }
+        case TranslateMode.OnlyTranslation: {
+          hideOriginalSubtitle();
+          const translation = await translateSubtitle(subtitle);
+          appendTranslatedSubtitle(translation, '100%');
+          showTranslatedSubtitle();
+          if (activationKeyPressed) {
+            hideTranslatedSubtitle();
+            resetOriginalSubtitle();
+          }
           break;
         }
         case TranslateMode.Disabled: {

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -86,7 +86,7 @@ export default defineContentScript({
             video.pause();
             video.focus();
             break;
-          case TranslateMode.OnlyTranslation:
+          case TranslateMode.TranslationOnly:
             hideTranslatedSubtitle();
             video.pause();
             video.focus();
@@ -105,7 +105,7 @@ export default defineContentScript({
             video.play();
             video.focus();
             break;
-          case TranslateMode.OnlyTranslation:
+          case TranslateMode.TranslationOnly:
             hideOriginalSubtitle();
             showTranslatedSubtitle();
             video.play();
@@ -137,7 +137,7 @@ export default defineContentScript({
           if (!activationKeyPressed) hideTranslatedSubtitle();
           break;
         }
-        case TranslateMode.OnlyTranslation: {
+        case TranslateMode.TranslationOnly: {
           hideOriginalSubtitle();
           const translation = await translateSubtitle(subtitle);
           appendTranslatedSubtitle(translation, '100%');

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -36,16 +36,19 @@ function App() {
         </select>
       </div>
       <div>
-        <label htmlFor="settings-mode">Translated language</label>
+        <label htmlFor="settings-mode">Mode:</label>
         <select id="settings-mode" onChange={handleModeChange}>
           <option selected={mode === TranslateMode.Enabled} value={TranslateMode.Enabled}>
-            Always Show
+            Dual mode
           </option>
           <option selected={mode === TranslateMode.KeyPress} value={TranslateMode.KeyPress}>
             When holding "T"
           </option>
+          <option selected={mode === TranslateMode.OnlyTranslation} value={TranslateMode.OnlyTranslation}>
+            Only translation
+          </option>
           <option selected={mode === TranslateMode.Disabled} value={TranslateMode.Disabled}>
-            Hidden
+            Disabled
           </option>
         </select>
       </div>

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -39,13 +39,13 @@ function App() {
         <label htmlFor="settings-mode">Mode:</label>
         <select id="settings-mode" onChange={handleModeChange}>
           <option selected={mode === TranslateMode.Enabled} value={TranslateMode.Enabled}>
-            Dual mode
+            Dual Mode
           </option>
           <option selected={mode === TranslateMode.KeyPress} value={TranslateMode.KeyPress}>
             When holding "T"
           </option>
-          <option selected={mode === TranslateMode.OnlyTranslation} value={TranslateMode.OnlyTranslation}>
-            Only translation
+          <option selected={mode === TranslateMode.TranslationOnly} value={TranslateMode.TranslationOnly}>
+            Translation Only
           </option>
           <option selected={mode === TranslateMode.Disabled} value={TranslateMode.Disabled}>
             Disabled

--- a/types/TranslateMode.ts
+++ b/types/TranslateMode.ts
@@ -1,5 +1,6 @@
 export enum TranslateMode {
   Enabled = 'enabled',
   Disabled = 'disabled',
-  KeyPress = 'keypress'
+  KeyPress = 'keypress',
+  OnlyTranslation = 'only-translation'
 }

--- a/types/TranslateMode.ts
+++ b/types/TranslateMode.ts
@@ -2,5 +2,5 @@ export enum TranslateMode {
   Enabled = 'enabled',
   Disabled = 'disabled',
   KeyPress = 'keypress',
-  OnlyTranslation = 'only-translation'
+  TranslationOnly = 'translation-only'
 }


### PR DESCRIPTION
Hi Rio! Thanks for this excellent extension. 
_It's something I wanted to do myself, but then I discovered your extension and it works perfectly!_

I was just wondering if a mode to **hide the original subtitles** would be useful too, and I found out [I'm not the only one considering it](https://github.com/rioam2/nrktv-dual-subs/issues/6). Which convinced me to write such a feature...
So this pull request also resolves #6.

**Translation Only** mode is fully compatible with your original modes, I just took the liberty of renaming the modes and I hope you don't mind 🙈

It also includes a feature that when you hold down the `T` button it will pause the video and show the original translation.

So I hope you find it useful too and I look forward to trying it out in the production version ;)

Tusen takk

<img width="279" alt="image" src="https://github.com/user-attachments/assets/a17d1914-9809-42be-95c0-c987f13e48c1" />


<img width="585" alt="image" src="https://github.com/user-attachments/assets/91b91efc-e36b-48ec-8c50-f7eed8c33e58" />
<img width="583" alt="image" src="https://github.com/user-attachments/assets/49277101-7656-4228-9ec9-6b33e9b755e7" />
<img width="640" alt="image" src="https://github.com/user-attachments/assets/c9b42e87-0eaa-44c7-a065-af754c040a95" />
