### PR TITLE
fix: simplify & reduce flakeyness of subtitle observer

### DIFF
--- a/constants/selectors.ts
+++ b/constants/selectors.ts
@@ -1,6 +1,5 @@
 export const SETTINGS_MODAL_QUERY_SELECTOR = 'player-settings-dialog';
-export const SUBTITLES_CONTAINER_QUERY_SELECTOR = 'tv-player-subtitles';
-export const SUBTITLE_WRAPPER_QUERY_SELECTOR = 'tv-player-subtitles div';
+export const SUBTITLE_WRAPPER_QUERY_SELECTOR = 'tv-player-subtitles > div';
 export const SUBTITLE_TEXT_QUERY_SELECTOR = '.tv-player-subtitle-text';
 export const TRANSLATED_SUBTITLE_TEXT_QUERY_SELECTOR = '*[data-translated="true"]';
 export const VIDEO_PLAYER_QUERY_SELECTOR = 'tv-player video';


### PR DESCRIPTION
Fixes a bug where the subtitle observer would not trigger when navigating through NRK between viewing sessions.
This also simplifies the two-step `MutationObserver` logic from before into a single observer which should be more reliable and robust.

A `distinctUntilChanged` operator was applied to the subtitle observer to reduce redundant translations if triggered multiple times for the same subtitle.