### PR TITLE
feat: add Chrome translator API as a fallback

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -76,18 +76,17 @@ export default defineContentScript({
       shiftOriginalSubtitle();
     }
 
-    async function getBuiltinTranslatorApi(targetLanguage?: string) {
-      if (!('Translator' in self) || !self.Translator || !targetLanguage) {
+    async function getBuiltinTranslatorApi(options: TranslatorOptions) {
+      if (!('Translator' in self) || !self.Translator) {
         return null;
       }
-      const translatorOptions = { sourceLanguage: 'no', targetLanguage };
-      const translatorCapabilities = await self.Translator.availability(translatorOptions);
+      const translatorCapabilities = await self.Translator.availability(options);
       switch (translatorCapabilities) {
         case 'available':
-          return await self.Translator.create(translatorOptions);
+          return await self.Translator.create(options);
         case 'downloadable':
-          // Trigger model download for next time (don't await)
-          self.Translator.create(translatorOptions);
+          // Trigger model download for next time (optimistic, don't await or care about result)
+          self.Translator.create(options).catch(() => {});
           return null;
         default:
           return null;
@@ -95,7 +94,10 @@ export default defineContentScript({
     }
 
     async function translateSubtitleUsingBuiltinApi(subtitle: string[]): Promise<string> {
-      const translatorApi = await getBuiltinTranslatorApi(language);
+      const translatorApi = await getBuiltinTranslatorApi({
+        sourceLanguage: 'no',
+        targetLanguage: language || 'en'
+      });
       if (translatorApi) {
         const translatedLines = await Promise.all(subtitle.map((line) => translatorApi.translate(line)));
         return translatedLines.join('\n');

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -76,7 +76,34 @@ export default defineContentScript({
       shiftOriginalSubtitle();
     }
 
-    async function translateSubtitle(subtitle: string[]): Promise<string> {
+    async function getBuiltinTranslatorApi(targetLanguage?: string) {
+      if (!('Translator' in self) || !self.Translator || !targetLanguage) {
+        return null;
+      }
+      const translatorOptions = { sourceLanguage: 'no', targetLanguage };
+      const translatorCapabilities = await self.Translator.availability(translatorOptions);
+      switch (translatorCapabilities) {
+        case 'available':
+          return await self.Translator.create(translatorOptions);
+        case 'downloadable':
+          // Trigger model download for next time (don't await)
+          self.Translator.create(translatorOptions);
+          return null;
+        default:
+          return null;
+      }
+    }
+
+    async function translateSubtitleUsingBuiltinApi(subtitle: string[]): Promise<string> {
+      const translatorApi = await getBuiltinTranslatorApi(language);
+      if (translatorApi) {
+        const translatedLines = await Promise.all(subtitle.map((line) => translatorApi.translate(line)));
+        return translatedLines.join('\n');
+      }
+      throw new Error('Built-in Translator API not available');
+    }
+
+    async function translateSubtitleUsingNetwork(subtitle: string[]): Promise<string> {
       const translation = await browser.runtime.sendMessage({
         action: ExtensionMessageAction.Translate,
         payload: {
@@ -87,6 +114,16 @@ export default defineContentScript({
       } as ExtensionMessage);
       if (translation.error) throw translation.error;
       return translation.response;
+    }
+
+    async function translateSubtitle(subtitle: string[]): Promise<string> {
+      return await Promise.any([
+        // Try both translation methods and use whichever is fastest
+        // This also provides a stable fallback in case one method fails
+        // (e.g. built-in API not available, network request fails, etc.)
+        translateSubtitleUsingBuiltinApi(subtitle),
+        translateSubtitleUsingNetwork(subtitle)
+      ]);
     }
 
     document.addEventListener('keydown', (e) => {

--- a/entrypoints/global.d.ts
+++ b/entrypoints/global.d.ts
@@ -1,0 +1,17 @@
+interface TranslatorOptions {
+  sourceLanguage: string;
+  targetLanguage: string;
+}
+
+type TranslatorAvailability = 'available' | 'downloadable' | 'unknown';
+
+declare global {
+  interface Window {
+    Translator?: {
+      availability(options: TranslatorOptions): Promise<TranslatorAvailability>;
+      create(options: TranslatorOptions): Promise<{ translate: (text: string) => Promise<string> }>;
+    };
+  }
+}
+
+export default {};

--- a/entrypoints/global.d.ts
+++ b/entrypoints/global.d.ts
@@ -1,11 +1,9 @@
-interface TranslatorOptions {
-  sourceLanguage: string;
-  targetLanguage: string;
-}
-
-type TranslatorAvailability = 'available' | 'downloadable' | 'unknown';
-
 declare global {
+  interface TranslatorOptions {
+    sourceLanguage: string;
+    targetLanguage: string;
+  }
+  type TranslatorAvailability = 'available' | 'downloadable' | 'unknown';
   interface Window {
     Translator?: {
       availability(options: TranslatorOptions): Promise<TranslatorAvailability>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nrktv-dual-subs",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nrktv-dual-subs",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "hasInstallScript": true,
       "license": "LICENSE",
       "dependencies": {


### PR DESCRIPTION
This pull request refactors the subtitle translation logic in `entrypoints/content.ts` to improve reliability and performance by introducing a fallback mechanism between two translation methods. The main change is that subtitle translation now attempts both the built-in browser Translator API as well as the existing network-based translation, using whichever succeeds first.

* Added `getBuiltinTranslatorApi` and `translateSubtitleUsingBuiltinApi` functions to utilize the browser's built-in Translator API if available, with model download handling and capability checks.
* Added `translateSubtitleUsingNetwork` function to perform translation via network request as a fallback method.
* Refactored `translateSubtitle` to use `Promise.any`, concurrently attempting both translation methods and returning the result from the first successful one, providing robustness against API availability and network connectivity issues.