### PR TITLE
Implement seamless translation without delay or placeholders

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -16,10 +16,33 @@ export default defineContentScript({
   allFrames: true,
   runAt: 'document_start',
   async main() {
+    const TRANSLATION_CACHE_LIMIT = 100;
+    const TRANSLATION_PREFETCH_AHEAD = 3;
+
     let mode: TranslateMode | undefined;
     let language: string | undefined;
     let activationKey: string | undefined;
     let activationKeyPressed = false;
+    let subtitleRequestId = 0;
+
+    const translationCache = new Map<string, string>();
+    const translationInFlight = new Map<string, Promise<string>>();
+
+    function subtitleToKey(subtitle: string[]): string {
+      return subtitle.join('\n');
+    }
+
+    function rememberTranslation(key: string, translation: string) {
+      if (translationCache.has(key)) {
+        translationCache.delete(key);
+      }
+      translationCache.set(key, translation);
+
+      if (translationCache.size > TRANSLATION_CACHE_LIMIT) {
+        const oldest = translationCache.keys().next().value;
+        if (oldest) translationCache.delete(oldest);
+      }
+    }
 
     function shiftOriginalSubtitle() {
       const subtitleContainer = document.querySelector(SUBTITLE_WRAPPER_QUERY_SELECTOR) as HTMLDivElement;
@@ -128,6 +151,67 @@ export default defineContentScript({
       ]);
     }
 
+    function cueTextToSubtitle(cueText: string): string[] {
+      return cueText
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => !!line);
+    }
+
+    async function getOrCreateTranslation(subtitle: string[]): Promise<string> {
+      const key = subtitleToKey(subtitle);
+      const cached = translationCache.get(key);
+      if (cached) return cached;
+
+      const existingPromise = translationInFlight.get(key);
+      if (existingPromise) return await existingPromise;
+
+      const translationPromise = translateSubtitle(subtitle)
+        .then((translation) => {
+          rememberTranslation(key, translation);
+          return translation;
+        })
+        .finally(() => {
+          translationInFlight.delete(key);
+        });
+
+      translationInFlight.set(key, translationPromise);
+      return await translationPromise;
+    }
+
+    function prefetchUpcomingSubtitleTranslations() {
+      const video = document.querySelector(VIDEO_PLAYER_QUERY_SELECTOR) as HTMLVideoElement | null;
+      if (!video) return;
+
+      for (let trackIndex = 0; trackIndex < video.textTracks.length; trackIndex++) {
+        const track = video.textTracks[trackIndex];
+        const cues = track.cues;
+        if (!cues?.length) continue;
+
+        const activeCue = track.activeCues?.[0] ?? null;
+        let activeIndex = -1;
+
+        if (activeCue) {
+          for (let cueIndex = 0; cueIndex < cues.length; cueIndex++) {
+            if (cues[cueIndex] === activeCue) {
+              activeIndex = cueIndex;
+              break;
+            }
+          }
+        }
+
+        const startIndex = Math.max(activeIndex + 1, 0);
+        const endIndex = Math.min(startIndex + TRANSLATION_PREFETCH_AHEAD, cues.length);
+
+        for (let cueIndex = startIndex; cueIndex < endIndex; cueIndex++) {
+          const cue = cues[cueIndex] as TextTrackCue;
+          const cueSubtitle = cueTextToSubtitle((cue as VTTCue).text ?? '');
+          if (!cueSubtitle.length) continue;
+          void getOrCreateTranslation(cueSubtitle);
+        }
+      }
+    }
+
     document.addEventListener('keydown', (e) => {
       if (e.key === activationKey) {
         e.preventDefault();
@@ -172,7 +256,16 @@ export default defineContentScript({
     });
 
     // Listen for settings changes
-    settings$.language.forEach((newLanguage) => (language = newLanguage));
+    settings$.language.forEach((newLanguage) => {
+      if (language !== newLanguage) {
+        // Invalidate buffered translations so old language results never leak into new language mode.
+        translationCache.clear();
+        translationInFlight.clear();
+        subtitleRequestId++;
+        removeTranslatedSubtitle();
+      }
+      language = newLanguage;
+    });
     settings$.mode.forEach((newMode) => (mode = newMode));
     settings$.activationKey.forEach((newActivationKey) => (activationKey = newActivationKey));
 
@@ -182,23 +275,24 @@ export default defineContentScript({
     });
 
     subtitles$.forEach(async (subtitle) => {
-      // Clean up previous subtitles
-      removeTranslatedSubtitle();
+      const currentRequestId = ++subtitleRequestId;
+      prefetchUpcomingSubtitleTranslations();
 
       switch (mode) {
         case TranslateMode.Enabled: {
           shiftOriginalSubtitle();
-          appendTranslatedSubtitle('...');
-          const translation = await translateSubtitle(subtitle);
+          const translation = await getOrCreateTranslation(subtitle);
+          if (currentRequestId !== subtitleRequestId) return;
           removeTranslatedSubtitle();
           appendTranslatedSubtitle(translation);
           showTranslatedSubtitle();
           break;
         }
         case TranslateMode.KeyPress: {
-          appendTranslatedSubtitle('...');
+          removeTranslatedSubtitle();
           hideTranslatedSubtitle();
-          const translation = await translateSubtitle(subtitle);
+          const translation = await getOrCreateTranslation(subtitle);
+          if (currentRequestId !== subtitleRequestId) return;
           removeTranslatedSubtitle();
           appendTranslatedSubtitle(translation);
           if (!activationKeyPressed) hideTranslatedSubtitle();
@@ -206,7 +300,9 @@ export default defineContentScript({
         }
         case TranslateMode.TranslationOnly: {
           hideOriginalSubtitle();
-          const translation = await translateSubtitle(subtitle);
+          const translation = await getOrCreateTranslation(subtitle);
+          if (currentRequestId !== subtitleRequestId) return;
+          removeTranslatedSubtitle();
           appendTranslatedSubtitle(translation, '100%');
           showTranslatedSubtitle();
           if (activationKeyPressed) {
@@ -216,6 +312,8 @@ export default defineContentScript({
           break;
         }
         case TranslateMode.Disabled: {
+          removeTranslatedSubtitle();
+          resetOriginalSubtitle();
           break;
         }
       }


### PR DESCRIPTION
This pull request introduces a subtitle translation caching and prefetching system to improve performance and user experience when translating subtitles in the content script. The changes focus on reducing redundant translation requests, ensuring translations are consistent with the selected language, and prefetching upcoming subtitle translations for smoother playback.

**Subtitle translation caching and prefetching:**

* Added a translation cache (`translationCache`) with a configurable limit to store recently translated subtitles and avoid redundant translation requests. Also introduced an in-flight promise map (`translationInFlight`) to prevent duplicate requests for the same subtitle.
* Implemented a prefetching mechanism (`prefetchUpcomingSubtitleTranslations`) that preloads translations for the next few upcoming subtitles to minimize latency during playback.
* Refactored translation retrieval to use a new `getOrCreateTranslation` function, which checks the cache/in-flight map before calling the translation API, and ensures only one translation request per subtitle at a time. [[1]](diffhunk://#diff-8ce8b0bd9bcf8126ac7f1637f4042ae7f73a441c83098baa95a97dea642ce84bR154-R214) [[2]](diffhunk://#diff-8ce8b0bd9bcf8126ac7f1637f4042ae7f73a441c83098baa95a97dea642ce84bL185-R305)

**Language change handling:**

* On language change, invalidates both the translation cache and in-flight requests, increments a request ID to prevent race conditions, and removes any displayed translated subtitles to ensure that subtitles from the previous language do not appear.

**Subtitle rendering improvements:**

* Ensured that translated subtitles are properly removed and reset when switching modes or disabling translation, preventing display artifacts and keeping the UI consistent.